### PR TITLE
Add page_size config option

### DIFF
--- a/tap_mailchimp/client.py
+++ b/tap_mailchimp/client.py
@@ -19,6 +19,7 @@ class MailchimpClient(object):
         self.__api_key = config.get('api_key')
         self.__session = requests.Session()
         self.__base_url = None
+        self.page_size = int(config.get('page_size', '1000'))
 
         if not self.__access_token and self.__api_key:
             self.__base_url = 'https://{}.api.mailchimp.com'.format(

--- a/tap_mailchimp/sync.py
+++ b/tap_mailchimp/sync.py
@@ -98,12 +98,12 @@ def sync_endpoint(client,
 
     write_schema(catalog, stream_name)
 
-    count = 1000
+    page_size = client.page_size
     offset = 0
     has_more = True
     while has_more:
         params = {
-            'count': count,
+            'count': page_size,
             'offset': offset,
             **static_params
         }
@@ -114,7 +114,7 @@ def sync_endpoint(client,
         LOGGER.info('{} - Syncing - {}count: {}, offset: {}'.format(
             stream_name,
             'since: {}, '.format(last_datetime) if bookmark_query_field else '',
-            count,
+            page_size,
             offset))
 
         data = client.get(
@@ -124,7 +124,7 @@ def sync_endpoint(client,
 
         raw_records = data.get(data_key)
 
-        if len(raw_records) < count:
+        if len(raw_records) < page_size:
             has_more = False
 
         max_bookmark_field = process_records(catalog,
@@ -139,7 +139,7 @@ def sync_endpoint(client,
                            bookmark_path,
                            max_bookmark_field)
 
-        offset += count
+        offset += page_size
 
     return ids
 


### PR DESCRIPTION
https://stitchdata.atlassian.net/browse/SUP-887

Mailchimp's API will return 500s when requests time out. When this occurs, the request does not get removed from the concurrent request count, and can result in persistent 429 errors as well. This PR adds a tuning knob to the config file to reduce the amount of data requested at once in an attempt to avoid 500 error responses.

More info in Mailchimp's Error documentation: https://mailchimp.com/developer/guides/error-glossary/

---

Co-Author: @jacobrobertbaca 