### PR TITLE
Stop initializing the transformer for every record

### DIFF
--- a/tap_mailchimp/client.py
+++ b/tap_mailchimp/client.py
@@ -3,8 +3,11 @@ from datetime import datetime, timedelta
 
 import backoff
 import requests
+import singer
 from requests.exceptions import ConnectionError
 from singer import metrics
+
+LOGGER = singer.get_logger()
 
 class ClientRateLimitError(Exception):
     pass
@@ -72,6 +75,7 @@ class MailchimpClient(object):
             kwargs['stream'] = True
 
         with metrics.http_request_timer(endpoint) as timer:
+            LOGGER.info("Executing %s request to %s with params: %s", method, url, kwargs.get('params'))
             response = self.__session.request(method, url, **kwargs)
             timer.tags[metrics.Tag.http_status_code] = response.status_code
 

--- a/tap_mailchimp/sync.py
+++ b/tap_mailchimp/sync.py
@@ -39,17 +39,16 @@ def process_records(catalog,
     stream = catalog.get_stream(stream_name)
     schema = stream.schema.to_dict()
     stream_metadata = metadata.to_map(stream.metadata)
-    with metrics.record_counter(stream_name) as counter:
+    with metrics.record_counter(stream_name) as counter, Transformer() as transformer:
         for record in records:
             if bookmark_field:
                 if max_bookmark_field is None or \
                     record[bookmark_field] > max_bookmark_field:
                     max_bookmark_field = record[bookmark_field]
             if persist:
-                with Transformer() as transformer:
-                    record = transformer.transform(record,
-                                                   schema,
-                                                   stream_metadata)
+                record = transformer.transform(record,
+                                               schema,
+                                               stream_metadata)
                 singer.write_record(stream_name, record)
                 counter.increment()
         return max_bookmark_field


### PR DESCRIPTION
# Description of change
Instead of initializing the transformer once per record, initialize it once per batch of records to cut down on the `Filtered paths during transform messages`

# Manual QA steps
 - Manually ran sync jobs, with significant reduction in log messages
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
