### PR TITLE
Add campaign ID logging to email_activity sync to improve auditability

### DIFF
--- a/tap_mailchimp/sync.py
+++ b/tap_mailchimp/sync.py
@@ -277,8 +277,9 @@ def stream_email_activity(client, catalog, state, archive_url):
                 if file.isfile():
                     rawoperations = tar.extractfile(file)
                     operations = json.loads(rawoperations.read().decode('utf-8'))
-                    for operation in operations:
+                    for i, operation in enumerate(operations):
                         campaign_id = operation['operation_id']
+                        LOGGER.info("reports_email_activity - [batch operation %s] Processing records for campaign %s", i, campaign_id)
                         if operation['status_code'] != 200:
                             failed_campaign_ids.append(campaign_id)
                         else:
@@ -339,7 +340,7 @@ def sync_email_activity(client, catalog, state, start_date, campaign_ids):
 
     data = poll_email_activity(client, state, batch_id)
 
-    LOGGER.info('reports_email_activity batch job complete: took {:.2f} minutes'.format(
+    LOGGER.info('reports_email_activity - Batch job complete: took {:.2f} minutes'.format(
         (strptime_to_utc(data['completed_at']) - strptime_to_utc(data['submitted_at']))
         .total_seconds() / 60))
 
@@ -347,6 +348,7 @@ def sync_email_activity(client, catalog, state, start_date, campaign_ids):
                                                 catalog,
                                                 state,
                                                 data['response_body_url'])
+    LOGGER.warning("reports_email_activity - Job failed for campaign_ids: %s", failed_campaign_ids)
 
     write_activity_batch_bookmark(state, None)
 

--- a/tap_mailchimp/sync.py
+++ b/tap_mailchimp/sync.py
@@ -348,7 +348,7 @@ def sync_email_activity(client, catalog, state, start_date, campaign_ids):
                                                 catalog,
                                                 state,
                                                 data['response_body_url'])
-    LOGGER.warning("reports_email_activity - Job failed for campaign_ids: %s", failed_campaign_ids)
+    LOGGER.warning("reports_email_activity - operations failed for campaign_ids: %s", failed_campaign_ids)
 
     write_activity_batch_bookmark(state, None)
 


### PR DESCRIPTION
# Description of change
The tap isn't logging any information about where it is at in the (potentially enormous) `reports_email_activity` stream. When this occurs, it is nearly impossible to run the whole dataset again, due to the extreme volume of the data.

This PR adds a log line per-campaign, showing which operation in the batch it's processing, and what campaign ID that is associated with. This should improve log auditability in the event of an error during this stream's sync.

# Manual QA steps
 - Ran through each of the log lines manually with mock data to ensure that it's doing what I expect
 
# Risks
 - Low, it's only logging
 
# Rollback steps
 - revert this branch, bump patch version, and release a new version
