### PR TITLE
Request chunks of campaigns for reports_email_activity

### DIFF
--- a/tap_mailchimp/sync.py
+++ b/tap_mailchimp/sync.py
@@ -18,7 +18,7 @@ MAX_RETRY_INTERVAL = 300 # 5 minutes
 MAX_RETRY_ELAPSED_TIME = 43200 # 12 hours
 
 # Break up reports_email_activity batches to iterate over chunks
-EMAIL_ACTIVITY_BATCH_SIZE = 10
+EMAIL_ACTIVITY_BATCH_SIZE = 100
 
 class BatchExpiredError(Exception):
     pass
@@ -188,7 +188,7 @@ def sync_stream(client,
 
         if endpoint_config.get('store_ids'):
             id_bag[stream_name] = stream_ids
-        
+
         children = endpoint_config.get('children')
         if children:
             for child_stream_name, child_endpoint_config in children.items():
@@ -299,17 +299,7 @@ def stream_email_activity(client, catalog, state, archive_url):
                 file = tar.next()
     return failed_campaign_ids
 
-def sync_email_activity(client, catalog, state, start_date, campaign_ids):
-    batch_id = get_bookmark(state, ['reports_email_activity_last_run_id'], None)
-
-    if batch_id:
-        try:
-            get_batch_info(client, batch_id)
-        except BatchExpiredError:
-            LOGGER.info('reports_email_activity - Previous run from state expired: {}'.format(
-                batch_id))
-            batch_id = None
-
+def sync_email_activity(client, catalog, state, start_date, campaign_ids, batch_id=None):
     if batch_id:
         LOGGER.info('reports_email_activity - Picking up previous run: {}'.format(batch_id))
     else:
@@ -375,9 +365,9 @@ def should_sync_stream(streams_to_sync, dependants, stream_name):
             return True, should_persist
     return False, should_persist
 
-def chunk_campaigns(sorted_campaigns):
-    chunk_start = 0
-    chunk_end = EMAIL_ACTIVITY_BATCH_SIZE
+def chunk_campaigns(sorted_campaigns, chunk_bookmark):
+    chunk_start = chunk_bookmark * EMAIL_ACTIVITY_BATCH_SIZE
+    chunk_end = chunk_start + EMAIL_ACTIVITY_BATCH_SIZE
 
     done = False
     while not done:
@@ -387,6 +377,21 @@ def chunk_campaigns(sorted_campaigns):
             yield current_chunk
         chunk_start = chunk_end
         chunk_end += EMAIL_ACTIVITY_BATCH_SIZE
+
+def check_and_resume_email_activity_batch(client, catalog, state, start_date):
+    batch_id = get_bookmark(state, ['reports_email_activity_last_run_id'], None)
+
+    if batch_id:
+        try:
+            get_batch_info(client, batch_id)
+        except BatchExpiredError:
+            LOGGER.info('reports_email_activity - Previous run from state expired: {}'.format(
+                batch_id))
+            batch_id = None
+
+        # Resume from bookmarked job_id, then if completed, issue a new batch for processing.
+        campaigns = [] # Don't need a list of campaigns if resuming
+        sync_email_activity(client, catalog, state, start_date, campaigns, batch_id)
 
 ## TODO: is current_stream being updated?
 
@@ -464,7 +469,14 @@ def sync(client, catalog, state, start_date):
                                                        'reports_email_activity')
     campaign_ids = id_bag.get('campaigns')
     if should_stream and campaign_ids:
-        # TODO: Bookmark offset?
+        # Resume previous batch, if necessary
+        check_and_resume_email_activity_batch(client, catalog, state, start_date)
+        # Chunk batch_ids, bookmarking the chunk number
         sorted_campaigns = sorted(campaign_ids)
-        for campaign_chunk in chunk_campaigns(sorted_campaigns):
+        chunk_bookmark = get_bookmark(state, ['reports_email_activity_last_chunk'], 0)
+        for i, campaign_chunk in enumerate(chunk_campaigns(sorted_campaigns, chunk_bookmark)):
+            state = write_bookmark(state, ['reports_email_activity_last_chunk'], chunk_bookmark + i)
             sync_email_activity(client, catalog, state, start_date, campaign_chunk)
+
+        # Start from the beginning next time
+        state = write_bookmark(state, ['reports_email_activity_last_chunk'], 0)

--- a/tap_mailchimp/sync.py
+++ b/tap_mailchimp/sync.py
@@ -369,11 +369,20 @@ def chunk_campaigns(sorted_campaigns, chunk_bookmark):
     chunk_start = chunk_bookmark * EMAIL_ACTIVITY_BATCH_SIZE
     chunk_end = chunk_start + EMAIL_ACTIVITY_BATCH_SIZE
 
+    if chunk_bookmark > 0:
+        LOGGER.info("reports_email_activity - Resuming requests starting at campaign_id %s/%s in chunks of %s",
+                    chunk_start,
+                    len(sorted_campaigns),
+                    EMAIL_ACTIVITY_BATCH_SIZE)
+
     done = False
     while not done:
         current_chunk = sorted_campaigns[chunk_start:chunk_end]
         done = len(current_chunk) == 0
         if not done:
+            LOGGER.info("reports_email_activity - Will request for campaign_ids from %s to %s",
+                        chunk_start,
+                        min(chunk_end, len(sorted_campaigns))
             yield current_chunk
         chunk_start = chunk_end
         chunk_end += EMAIL_ACTIVITY_BATCH_SIZE

--- a/tap_mailchimp/sync.py
+++ b/tap_mailchimp/sync.py
@@ -403,11 +403,15 @@ def check_and_resume_email_activity_batch(client, catalog, state, start_date):
 
     if batch_id:
         try:
-            get_batch_info(client, batch_id)
+            data = get_batch_info(client, batch_id)
+            if not data['response_body_url']:
+                LOGGER.info('reports_email_activity - Previous run from state ({}) is empty, retrying.'.format(
+                    batch_id))
+                return
         except BatchExpiredError:
             LOGGER.info('reports_email_activity - Previous run from state expired: {}'.format(
                 batch_id))
-            batch_id = None
+            return
 
         # Resume from bookmarked job_id, then if completed, issue a new batch for processing.
         campaigns = [] # Don't need a list of campaigns if resuming

--- a/tap_mailchimp/sync.py
+++ b/tap_mailchimp/sync.py
@@ -397,6 +397,8 @@ def write_email_activity_chunk_bookmark(state, current_bookmark, current_index, 
     next_chunk = current_bookmark + current_index + 1
     if next_chunk * EMAIL_ACTIVITY_BATCH_SIZE < len(sorted_campaigns):
         write_bookmark(state, ['reports_email_activity_next_chunk'], next_chunk)
+    else:
+        write_bookmark(state, ['reports_email_activity_next_chunk'], 0)
 
 def check_and_resume_email_activity_batch(client, catalog, state, start_date):
     batch_id = get_bookmark(state, ['reports_email_activity_last_run_id'], None)


### PR DESCRIPTION
# Description of change
Email Activity is a very large stream, and even larger if there are 1000+ campaigns to request activity for.

This PR is to reduce that size by breaking up the campaign IDs into chunks of 100 to issues reports for only that subset.

# Manual QA steps
 - I ran through this with the chunk size set to 1, and it worked well. That may be the best way to do it, so the tap can move forward.
    - When you get up to 1k+ campaigns, it takes weeks to complete a full job, so bookmarking will need to be added
 
# Risks
 - Medium. If bookmarking is not correct, this could cause the requests to spin on only the first N campaigns, alphabetically.
 
# Rollback steps
 - revert this branch, bump patch version, release
