### PR TITLE
bump to 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.1
+  * Request chunks of campaigns for email_activty reports [#21](https://github.com/singer-io/tap-mailchimp/pull/21)
+
 ## 1.0.0
   * Add `list_id` as a primary key for the `list_members` stream
   * Clean up logging

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-mailchimp',
-      version='1.0.0',
+      version='1.0.1',
       description='Singer.io tap for extracting data from the Mailchimp API',
       author='Stitch',
       url='https://singer.io',


### PR DESCRIPTION
# Description of change

Releases https://github.com/singer-io/tap-mailchimp/pull/21

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
