### PR TITLE
Fix resume batch logic

### DIFF
--- a/tap_mailchimp/sync.py
+++ b/tap_mailchimp/sync.py
@@ -402,12 +402,14 @@ def write_email_activity_chunk_bookmark(state, current_bookmark, current_index, 
         write_bookmark(state, ['reports_email_activity_next_chunk'], 0)
 
 def check_and_resume_email_activity_batch(client, catalog, state, start_date):
+    import ipdb; ipdb.set_trace()
+    1+1
     batch_id = get_bookmark(state, ['reports_email_activity_last_run_id'], None)
 
     if batch_id:
         try:
             data = get_batch_info(client, batch_id)
-            if not data['response_body_url']:
+            if data['status'] == 'finished' and not data['response_body_url']:
                 LOGGER.info('reports_email_activity - Previous run from state ({}) is empty, retrying.'.format(
                     batch_id))
                 return

--- a/tap_mailchimp/sync.py
+++ b/tap_mailchimp/sync.py
@@ -402,8 +402,6 @@ def write_email_activity_chunk_bookmark(state, current_bookmark, current_index, 
         write_bookmark(state, ['reports_email_activity_next_chunk'], 0)
 
 def check_and_resume_email_activity_batch(client, catalog, state, start_date):
-    import ipdb; ipdb.set_trace()
-    1+1
     batch_id = get_bookmark(state, ['reports_email_activity_last_run_id'], None)
 
     if batch_id:


### PR DESCRIPTION
# Description of change
Fixed the logic to check for if we should re-request a batch. Previously, it was just checking for if there wasn't a response body in the response, but now it checks that there is not a response body and that the status is finished to deem a re-request necessary.
# Manual QA steps
 - ran some requests and checked.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
