### PR TITLE
got fields to be filtered before being returned from mailchimp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,11 +18,6 @@ jobs:
             source /usr/local/share/virtualenvs/tap-mailchimp/bin/activate
             pylint tap_mailchimp --disable 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,bad-whitespace'
       - run:
-          name: 'Unit Tests'
-          command: |
-            source /usr/local/share/virtualenvs/tap-mailchimp/bin/activate
-            nosetests tap_mailchimp/tests
-      - run:
           name: 'JSON Validator'
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,60 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
+    steps:
+      - checkout
+      - run:
+          name: 'Setup virtual env'
+          command: |
+            python3 -m venv /usr/local/share/virtualenvs/tap-mailchimp/
+            source /usr/local/share/virtualenvs/tap-mailchimp/bin/activate
+            pip install -U 'pip<19.2' setuptools
+            pip install .[dev]
+      - run:
+          name: 'pylint'
+          command: |
+            source /usr/local/share/virtualenvs/tap-mailchimp/bin/activate
+            pylint tap_mailchimp --disable 'broad-except,chained-comparison,empty-docstring,fixme,invalid-name,line-too-long,missing-class-docstring,missing-function-docstring,missing-module-docstring,no-else-raise,no-else-return,too-few-public-methods,too-many-arguments,too-many-branches,too-many-lines,too-many-locals,ungrouped-imports,wrong-spelling-in-comment,wrong-spelling-in-docstring,bad-whitespace'
+      - run:
+          name: 'Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-mailchimp/bin/activate
+            nosetests tap_mailchimp/tests
+      - run:
+          name: 'JSON Validator'
+          command: |
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            stitch-validate-json /usr/local/share/virtualenvs/tap-mailchimp/lib/python3.5/site-packages/tap_mailchimp/schemas/*.json
+      - add_ssh_keys
+      - run:
+          name: 'Integration Tests'
+          command: |
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
+            source dev_env.sh
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            run-test --tap=tap-mailchimp \
+                     --target=target-stitch \
+                     --orchestrator=stitch-orchestrator \
+                     --email=harrison+sandboxtest@stitchdata.com \
+                     --password=$SANDBOX_PASSWORD \
+                     --client-id=50 \
+                     tests
+workflows:
+  version: 2
+  commit:
+    jobs:
+      - build:
+          context: circleci-user
+  build_daily:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build:
+          context: circleci-user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,11 @@ jobs:
             stitch-validate-json /usr/local/share/virtualenvs/tap-mailchimp/lib/python3.5/site-packages/tap_mailchimp/schemas/*.json
       - add_ssh_keys
       - run:
+          name: 'Unit Tests'
+          command: |
+            source /usr/local/share/virtualenvs/tap-mailchimp/bin/activate
+            nosetests ./tests/unittests
+      - run:
           name: 'Integration Tests'
           command: |
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh

--- a/setup.py
+++ b/setup.py
@@ -10,13 +10,14 @@ setup(name='tap-mailchimp',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_mailchimp'],
       install_requires=[
-          'backoff==1.3.2',
+          'backoff==1.8.0',
           'requests==2.20.1',
-          'singer-python==5.2.0'
+          'singer-python==5.9.0'
       ],
       extras_require= {
           'dev': [
               'pylint==2.5.3',
+              'nose==1.3.7',
           ]
       },
       entry_points='''

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,11 @@ setup(name='tap-mailchimp',
           'requests==2.20.1',
           'singer-python==5.2.0'
       ],
+      extras_require= {
+          'dev': [
+              'pylint==2.5.3',
+          ]
+      },
       entry_points='''
           [console_scripts]
           tap-mailchimp=tap_mailchimp:main

--- a/tap_mailchimp/client.py
+++ b/tap_mailchimp/client.py
@@ -1,10 +1,7 @@
-import json
-from datetime import datetime, timedelta
-
 import backoff
 import requests
 import singer
-from requests.exceptions import ConnectionError
+from requests.exceptions import ConnectionError # pylint: disable=redefined-builtin
 from singer import metrics
 
 LOGGER = singer.get_logger()
@@ -15,7 +12,7 @@ class ClientRateLimitError(Exception):
 class Server5xxError(Exception):
     pass
 
-class MailchimpClient(object):
+class MailchimpClient:
     def __init__(self, config):
         self.__user_agent = config.get('user_agent')
         self.__access_token = config.get('access_token')
@@ -31,7 +28,7 @@ class MailchimpClient(object):
     def __enter__(self):
         return self
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, type, value, traceback): # pylint: disable=redefined-builtin
         self.__session.close()
 
     def get_base_url(self):

--- a/tap_mailchimp/schema.py
+++ b/tap_mailchimp/schema.py
@@ -24,7 +24,7 @@ def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
 
 def get_schemas():
-    global SCHEMAS, FIELD_METADATA
+    global SCHEMAS, FIELD_METADATA # pylint: disable=global-statement
 
     if SCHEMAS:
         return SCHEMAS, FIELD_METADATA
@@ -38,12 +38,12 @@ def get_schemas():
         stream_name = file_name[:-5]
         with open(os.path.join(schemas_path, file_name)) as data_file:
             schema = json.load(data_file)
-            
+
         SCHEMAS[stream_name] = schema
         pk = PKS[stream_name]
 
         metadata = []
-        for prop, json_schema in schema['properties'].items():
+        for prop in schema['properties'].keys():
             if prop in pk:
                 inclusion = 'automatic'
             else:

--- a/tap_mailchimp/sync.py
+++ b/tap_mailchimp/sync.py
@@ -308,7 +308,9 @@ def sync_email_activity(client, catalog, state, start_date, campaign_ids, batch_
     else:
         LOGGER.info('reports_email_activity - Starting sync')
 
-        formatted_field_names = format_selected_fields(catalog, 'reports_email_activity', 'emails')
+        extra_fields = ['emails.activity']
+
+        formatted_field_names = format_selected_fields(catalog, 'reports_email_activity', 'emails', extra_fields)
 
         operations = []
         for campaign_id in campaign_ids:
@@ -359,7 +361,7 @@ def get_selected_streams(catalog):
             selected_streams.add(stream.tap_stream_id)
     return list(selected_streams)
 
-def format_selected_fields(catalog, stream_name, data_key):
+def format_selected_fields(catalog, stream_name, data_key, extra_fields=None):
     """Given a catalog with selected metadata return a comma separated string
     of the `data_key.field_name` for every selected field in the catalog plus
     the `extra_fields` defined below
@@ -378,8 +380,10 @@ def format_selected_fields(catalog, stream_name, data_key):
         if should_sync_field(field_metadata.get('inclusion'), field_metadata.get('selected')):
             formatted_field_names.append(data_key+'.'+field)
 
-    extra_fields = ['_links', 'total_items', 'constraints', data_key+'.'+'_links']
-    formatted_field_names += extra_fields
+    default_fields = ['_links', 'total_items', 'constraints', data_key+'.'+'_links']
+    formatted_field_names += default_fields
+    if extra_fields:
+        formatted_field_names += extra_fields
     return ",".join(formatted_field_names)
 
 

--- a/tap_mailchimp/sync.py
+++ b/tap_mailchimp/sync.py
@@ -65,7 +65,7 @@ def get_bookmark(state, path, default):
 def nested_set(dic, path, value):
     for key in path[:-1]:
         dic = dic.setdefault(key, {})
-        dic[path[-1]] = value
+    dic[path[-1]] = value
 
 def write_bookmark(state, path, value):
     nested_set(state, ['bookmarks'] + path, value)
@@ -92,7 +92,7 @@ def sync_endpoint(client,
         _id = record.get('id')
         if _id:
             ids.append(_id)
-            del record['_links']
+        del record['_links']
         return record
 
     write_schema(catalog, stream_name)
@@ -262,14 +262,14 @@ def stream_email_activity(client, catalog, state, archive_url):
             if 'activity' in record:
                 if '_links' in record:
                     del record['_links']
-                    record_template = dict(record)
-                    del record_template['activity']
+                record_template = dict(record)
+                del record_template['activity']
 
                 for activity in record['activity']:
                     new_activity = dict(record_template)
                     for key, value in activity.items():
                         new_activity[key] = value
-                        yield new_activity
+                    yield new_activity
 
     write_schema(catalog, stream_name)
 
@@ -299,7 +299,7 @@ def stream_email_activity(client, catalog, state, archive_url):
                             write_bookmark(state,
                                            [stream_name, campaign_id],
                                            max_bookmark_field)
-                            file = tar.next()
+                file = tar.next()
     return failed_campaign_ids
 
 def sync_email_activity(client, catalog, state, start_date, campaign_ids, batch_id=None):
@@ -400,8 +400,8 @@ def chunk_campaigns(sorted_campaigns, chunk_bookmark):
                         chunk_start,
                         end_index - 1)
             yield current_chunk
-            chunk_start = chunk_end
-            chunk_end += EMAIL_ACTIVITY_BATCH_SIZE
+        chunk_start = chunk_end
+        chunk_end += EMAIL_ACTIVITY_BATCH_SIZE
 
 def write_email_activity_chunk_bookmark(state, current_bookmark, current_index, sorted_campaigns):
     # Bookmark next chunk because the current chunk will be saved in batch_id

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,68 @@
+import tap_tester.connections as connections
+import tap_tester.menagerie   as menagerie
+import tap_tester.runner      as runner
+import os
+import unittest
+
+class TestMailchimpDiscovery(unittest.TestCase):
+    def setUp(self):
+        missing_envs = [x for x in [
+            "TAP_MAILCHIMP_CLIENT_ID",
+            "TAP_MAILCHIMP_CLIENT_SECRET",
+            "TAP_MAILCHIMP_ACCESS_TOKEN",
+        ] if os.getenv(x) == None]
+        if len(missing_envs) != 0:
+            raise Exception("Missing environment variables: {}".format(missing_envs))
+
+    def name(self):
+        return "tap_tester_mailchimp_discovery"
+
+    def get_type(self):
+        return "platform.mailchimp"
+
+    def get_credentials(self):
+        return {
+            'client_id': os.getenv('TAP_MAILCHIMP_CLIENT_ID'),
+            'client_secret': os.getenv('TAP_MAILCHIMP_CLIENT_SECRET'),
+            'access_token': os.getenv('TAP_MAILCHIMP_ACCESS_TOKEN')
+        }
+
+    def expected_check_streams(self):
+        return {
+            'automations',
+            'campaigns',
+            'list_members',
+            'list_segment_members',
+            'list_segments',
+            'lists',
+            'reports_email_activity',
+            'unsubscribes'
+        }
+
+    def tap_name(self):
+        return "tap-mailchimp"
+
+
+    def get_properties(self):
+        return {
+            'start_date' : '2019-09-01T00:00:00Z'
+        }
+
+    def test_run(self):
+        conn_id = connections.ensure_connection(self)
+
+        #run in check mode
+        check_job_name = runner.run_check_mode(self, conn_id)
+
+        #verify check exit codes
+        exit_status = menagerie.get_exit_status(conn_id, check_job_name)
+        menagerie.verify_check_exit_status(self, exit_status, check_job_name)
+
+        found_catalogs = menagerie.get_catalogs(conn_id)
+        self.assertGreater(len(found_catalogs), 0, msg="unable to locate schemas for connection {}".format(conn_id))
+
+        found_catalog_names = set(map(lambda c: c['tap_stream_id'], found_catalogs))
+
+        diff = self.expected_check_streams().symmetric_difference(found_catalog_names)
+        self.assertEqual(len(diff), 0, msg="discovered schemas do not match: {}".format(diff))
+        print("discovered schemas are OK")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,0 +1,118 @@
+import tap_tester.connections as connections
+import tap_tester.menagerie   as menagerie
+import tap_tester.runner      as runner
+import os
+import unittest
+from functools import reduce
+
+class MailchimpBookmarks(unittest.TestCase):
+    def setUp(self):
+        missing_envs = [x for x in [
+            "TAP_MAILCHIMP_CLIENT_ID",
+            "TAP_MAILCHIMP_CLIENT_SECRET",
+            "TAP_MAILCHIMP_ACCESS_TOKEN",
+        ] if os.getenv(x) == None]
+        if len(missing_envs) != 0:
+            raise Exception("Missing environment variables: {}".format(missing_envs))
+
+    def name(self):
+        return "tap_tester_mailchimp_discovery"
+
+    def get_type(self):
+        return "platform.mailchimp"
+
+    def get_credentials(self):
+        return {
+            'client_id': os.getenv('TAP_MAILCHIMP_CLIENT_ID'),
+            'client_secret': os.getenv('TAP_MAILCHIMP_CLIENT_SECRET'),
+            'access_token': os.getenv('TAP_MAILCHIMP_ACCESS_TOKEN')
+        }
+
+    def expected_check_streams(self):
+        return {
+            'automations',
+            'campaigns',
+            'list_members',
+            'list_segment_members',
+            'list_segments',
+            'lists',
+            'reports_email_activity',
+            'unsubscribes'
+        }
+
+    def tap_name(self):
+        return "tap-mailchimp"
+
+
+    def get_properties(self):
+        return {
+            'start_date' : '2019-09-01T00:00:00Z'
+        }
+
+
+    def expected_sync_streams(self):
+        return {
+            'campaigns': {'id'},
+            'list_segment_members': {'id'},
+            'list_segments': {'id'},
+            'lists': {'id'},
+            'reports_email_activity': {'campaign_id', 'action', 'email_id', 'timestamp'},
+            'unsubscribes': {'campaign_id', 'email_id'}
+        }
+
+    def test_run(self):
+        conn_id = connections.ensure_connection(self)
+
+        #run in check mode
+        check_job_name = runner.run_check_mode(self, conn_id)
+
+        #verify check  exit codes
+        exit_status = menagerie.get_exit_status(conn_id, check_job_name)
+        menagerie.verify_check_exit_status(self, exit_status, check_job_name)
+
+        found_catalogs = menagerie.get_catalogs(conn_id)
+        self.assertGreater(len(found_catalogs), 0, msg="unable to locate schemas for connection {}".format(conn_id))
+
+        found_catalog_names = set(map(lambda c: c['tap_stream_id'], found_catalogs))
+
+        diff = self.expected_check_streams().symmetric_difference( found_catalog_names )
+        self.assertEqual(len(diff), 0, msg="discovered schemas do not match: {}".format(diff))
+        print("discovered schemas are OK")
+
+        #select all catalogs
+
+        for c in found_catalogs:
+            catalog_entry = menagerie.get_annotated_schema(conn_id, c['stream_id'])
+            if c['stream_name'] in self.expected_sync_streams().keys():
+                stream = c['stream_name']
+                pks = self.expected_sync_streams()[stream]
+
+                for pk in pks:
+                    mdata = next((m for m in catalog_entry['metadata']
+                                  if len(m['breadcrumb']) == 2 and m['breadcrumb'][1] == pk), None)
+                    print("Validating inclusion on {}: {}".format(c['stream_name'], mdata))
+                    self.assertTrue(mdata and mdata['metadata']['inclusion'] == 'automatic')
+
+                connections.select_catalog_and_fields_via_metadata(conn_id, c, catalog_entry)
+
+        #clear state
+        menagerie.set_state(conn_id, {})
+
+        sync_job_name = runner.run_sync_mode(self, conn_id)
+
+        #verify tap and target exit codes
+        exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
+        menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
+
+        first_record_count_by_stream = runner.examine_target_output_file(self, conn_id, set(self.expected_sync_streams().keys()), self.expected_sync_streams())
+        replicated_row_count =  reduce(lambda accum,c : accum + c, first_record_count_by_stream.values())
+        self.assertGreater(replicated_row_count, 0, msg="failed to replicate any data: {}".format(first_record_count_by_stream))
+        print("total replicated row count: {}".format(replicated_row_count))
+
+        # Verify that automatic fields are all emitted with records
+        synced_records = runner.get_records_from_target_output()
+        for stream_name, data in synced_records.items():
+            record_messages = [set(row['data'].keys()) for row in data['messages']]
+            self.assertGreater(len(record_messages), 0, msg="stream {} did not sync any records.".format(stream_name))
+            for record_keys in record_messages:
+                self.assertEqual(self.expected_sync_streams().get(stream_name, set()) - record_keys, set())

--- a/tests/unittests/test_format_selected_fields.py
+++ b/tests/unittests/test_format_selected_fields.py
@@ -1,0 +1,40 @@
+import singer
+from tap_mailchimp.sync import format_selected_fields
+import unittest
+
+class TestFormatSelectedFields(unittest.TestCase):
+    
+    def test_format_selected_fields(self):
+        expected = 'key1.field1,key1.field2,_links,total_items,constraints,key1._links'
+        catalog = singer.Catalog.from_dict(
+            {"streams": [
+                {"tap_stream_id": "stream1",
+                 "schema": {"properties": {"field1" : {},
+                                           "field2": {}}},
+                 "metadata": [
+                     {"breadcrumb": [],
+                      "metadata": {
+                          "selected": True,
+                          "inclusion": "available"
+                      }},
+                     {"breadcrumb": ["properties", "field1"],
+                      "metadata": {
+                          "selected": True,
+                          "inclusion": "available"
+                      }},
+                     {"breadcrumb": ["properties", "field2"],
+                      "metadata": {
+                          "inclusion": "automatic"
+                      }},
+                     {"breadcrumb": ["properties", "field3"],
+                      "metadata": {
+                          "selected": False,
+                          "inclusion": "available"
+                      }},
+                 ]
+                }
+            ]}
+        )
+        actual = format_selected_fields(catalog, 'stream1', 'key1')
+        self.assertEqual(expected, actual)
+


### PR DESCRIPTION
# Description of change
got fields to be filtered before being returned from mailchimp
https://stitchdata.atlassian.net/secure/RapidBoard.jspa?rapidView=9&projectKey=SRCE&modal=detail&selectedIssue=SRCE-3517
Previously, we were filtering out after a response was returned from mailchimp.
Now, when we add fields to the 'fields' parameter, mailchimp will only return us the fields we ask for,
We had to modify the general sync_endpoint function as well as the sync_email_activity function, since the general calls a different batch endpoint.

# Manual QA steps
 - added fields 'fields' param for each stream
 - checked directly on response object to make sure only requested fields came through
 - ran sync for all streams and made sure the records went through fine
 - checked for diff between records output before this change and records output after, saw no diff
 - checked to make sure sync still worked with bookmarking

 - IMPORTANT TO NOTE: we weren't able to check that records came through for automations and list_members, since we don't have data for those, but we did follow the same pattern that all the other streams followed for naming the fields.
 
# Risks
 - low
 
# Rollback steps
 - revert this branch
