### PR TITLE
made last_changed a replication key on stream list_members

### DIFF
--- a/tap_mailchimp/schema.py
+++ b/tap_mailchimp/schema.py
@@ -20,6 +20,10 @@ PKS = {
     'unsubscribes': ['campaign_id', 'email_id']
 }
 
+REPLICATION_KEYS = {
+    'list_members': ['last_changed'],
+}
+
 def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
 
@@ -41,10 +45,11 @@ def get_schemas():
 
         SCHEMAS[stream_name] = schema
         pk = PKS[stream_name]
+        replication_keys = REPLICATION_KEYS.get(stream_name, [])
 
         metadata = []
         for prop in schema['properties'].keys():
-            if prop in pk:
+            if prop in pk or prop in replication_keys:
                 inclusion = 'automatic'
             else:
                 inclusion = 'available'

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -51,6 +51,7 @@ class MailchimpBookmarks(unittest.TestCase):
 
 
     def expected_sync_streams(self):
+        """This is a map from stream name to the automatic fields"""
         return {
             'campaigns': {'id'},
             'list_segment_members': {'id'},


### PR DESCRIPTION
# Description of change
made last_changed a replication key on stream list_members
changed tap-tester discovery to check that all automatic fields are marked as such on the catalog

# Manual QA steps
 - ran discovery and watched 'last_changed' come back as automatic
 - after modifying tests, ran tests with version of tap prior to replication key update, watched it fail. Then made the change and watched them pass
 
# Risks
 - low
 
# Rollback steps
 - revert this branch
