### PR TITLE
Update error message on campaigns job timeout

### DIFF
--- a/tap_mailchimp/sync.py
+++ b/tap_mailchimp/sync.py
@@ -243,8 +243,7 @@ def poll_email_activity(client, state, batch_id):
         if data['status'] == 'finished':
             return data
         elif (time.time() - start_time) > MAX_RETRY_ELAPSED_TIME:
-            message = 'campaigns - export deadline exceeded ({} secs)'.format(
-                MAX_RETRY_ELAPSED_TIME)
+            message = 'Mailchimp campaigns export is still in progress after {} seconds. Will continue with this export on the next sync.'.format(MAX_RETRY_ELAPSED_TIME)
             LOGGER.error(message)
             raise Exception(message)
 


### PR DESCRIPTION
# Description of change
Update error message on campaigns export timeout to indicate that nothing actually went wrong and the export will be continue to be extracted on the next sync.

# Manual QA steps
 - 
 
# Risks
 - Minimal. Logging changes only
 
# Rollback steps
 - revert this branch
