### PR TITLE
TDL-20303: Primary keys are not correct for reports_email_activity and list_segment_members stream

### DIFF
--- a/tap_mailchimp/schema.py
+++ b/tap_mailchimp/schema.py
@@ -40,6 +40,11 @@ def get_schemas():
             for replication_key in stream_obj.replication_keys:
                 mdata_map[('properties', replication_key)]['inclusion'] = 'automatic'
 
+        # Update inclusion for extra fields which we need to replicate data
+        if stream_obj.extra_automatic_fields:
+            for field in stream_obj.extra_automatic_fields:
+                mdata_map[('properties', field)]['inclusion'] = 'automatic'
+
         metadata_list = metadata.to_list(mdata_map)
         field_metadata[stream_name] = metadata_list
 

--- a/tap_mailchimp/schemas/reports_email_activity.json
+++ b/tap_mailchimp/schemas/reports_email_activity.json
@@ -2,6 +2,12 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "_sdc_record_hash": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "campaign_id": {
       "type": [
         "string"

--- a/tap_mailchimp/streams.py
+++ b/tap_mailchimp/streams.py
@@ -358,7 +358,7 @@ class ReportEmailActivity(Incremental):
     stream_name = 'reports_email_activity'
     extra_fields = ['emails.activity']
     key_properties = ['_sdc_record_hash']
-    streams_to_sync = ['campaigns']
+    parent_streams = ['campaigns']
     path = '/reports/{}/email-activity'
     data_key = 'emails'
     replication_keys = ['timestamp']

--- a/tap_mailchimp/streams.py
+++ b/tap_mailchimp/streams.py
@@ -348,7 +348,7 @@ class ReportEmailActivity(Incremental):
     data_key = 'emails'
     replication_keys = ['timestamp']
     # We must pass a list of fields for which we want data to the Mailchimp API.
-    # As a result, make these fields as automatic, as they are used to generate the '_sdc record hash' Primary Key.
+    # As a result, make these fields automatic, as they are used to generate the '_sdc record hash' Primary Key.
     extra_automatic_fields = ['campaign_id', 'action', 'email_id', 'timestamp', 'ip']
 
     def transform_activities(self, records):
@@ -367,9 +367,9 @@ class ReportEmailActivity(Incremental):
                     for key, value in activity.items():
                         new_activity[key] = value
 
-                    # Create hash string
+                    # Create hash string of key-value ie. key1value1key2value2...
                     for field in self.extra_automatic_fields:
-                        hash_string += str(new_activity.get(field, ''))
+                        hash_string += field + str(new_activity.get(field, ''))
 
                     hash_string_bytes = hash_string.encode('utf-8')
                     hashed_string = hashlib.sha256(hash_string_bytes).hexdigest()

--- a/tests/base.py
+++ b/tests/base.py
@@ -22,8 +22,7 @@ class MailchimpBaseTest(unittest.TestCase):
     OBEYS_START_DATE = "obey-start-date"
     BOOKMARK_PATH = "bookmark-path"
     EXTRA_AUTOMATIC_FIELDS = "extra-automatic-fields"
-    RECORD_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.000000Z"
-    BOOKMARK_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S+00:00"
+    BOOKMARK_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.000000Z"
     PARENT = "parent-stream"
 
     def tap_name(self):
@@ -116,7 +115,8 @@ class MailchimpBaseTest(unittest.TestCase):
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"timestamp"},
                 self.OBEYS_START_DATE: True,
-                self.BOOKMARK_PATH: ['reports_email_activity', '32e6edcecb'],
+                self.BOOKMARK_PATH: ["reports_email_activity", "32e6edcecb"],
+                self.PARENT: "campaigns",
                 self.EXTRA_AUTOMATIC_FIELDS: {'action', 'campaign_id', 'email_id', 'timestamp', 'ip'}
             },
             "unsubscribes": {

--- a/tests/base.py
+++ b/tests/base.py
@@ -20,6 +20,7 @@ class MailchimpBaseTest(unittest.TestCase):
     INCREMENTAL = "INCREMENTAL"
     OBEYS_START_DATE = "obey-start-date"
     BOOKMARK_PATH = "bookmark-path"
+    EXTRA_AUTOMATIC_FIELDS = "extra-automatic-fields"
     RECORD_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.000000Z"
     BOOKMARK_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S+00:00"
 
@@ -103,11 +104,12 @@ class MailchimpBaseTest(unittest.TestCase):
                 self.BOOKMARK_PATH: None
             },
             'reports_email_activity': {
-                self.PRIMARY_KEYS: {'action', 'campaign_id', 'email_id', 'timestamp'},
+                self.PRIMARY_KEYS: {'_sdc_record_hash'},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {'timestamp'},
                 self.OBEYS_START_DATE: True,
-                self.BOOKMARK_PATH: ['reports_email_activity', '32e6edcecb']
+                self.BOOKMARK_PATH: ['reports_email_activity', '32e6edcecb'],
+                self.EXTRA_AUTOMATIC_FIELDS: {'action', 'campaign_id', 'email_id', 'timestamp', 'ip'}
             },
             'unsubscribes': {
                 self.PRIMARY_KEYS: {'campaign_id', 'email_id'},
@@ -146,7 +148,8 @@ class MailchimpBaseTest(unittest.TestCase):
         """Return a dictionary with the key of table name and set of value of automatic(primary key and bookmark field) fields"""
         auto_fields = {}
         for k, v in self.expected_metadata().items():
-            auto_fields[k] = v.get(self.PRIMARY_KEYS, set()) |  v.get(self.REPLICATION_KEYS, set())
+            auto_fields[k] = v.get(self.PRIMARY_KEYS, set()) |  v.get(self.REPLICATION_KEYS, set()) | \
+                v.get(self.EXTRA_AUTOMATIC_FIELDS, set())
         return auto_fields
 
     def run_and_verify_check_mode(self, conn_id):

--- a/tests/test_mailchimp_automatic_fields.py
+++ b/tests/test_mailchimp_automatic_fields.py
@@ -60,10 +60,16 @@ class MailchimpAutomaticFields(MailchimpBaseTest):
 
                 # Verify that only the automatic fields are sent to the target
                 for actual_keys in record_messages_keys:
+                    # Not all records include 'ip'. But for our dataset 'ip' as differentiating field among non-similar records
+                    if stream == "reports_email_activity":
+                        actual_keys -= {"id"}
                     self.assertSetEqual(expected_keys, actual_keys)
-                    
-                # BUG: TDL-20303 PKs are not unique     
+
                 # Verify that all replicated records have unique primary key values.
-                # self.assertEqual(len(primary_keys_list), 
-                #                     len(unique_primary_keys_list), 
-                #                     msg="Replicated record does not have unique primary key values.")
+                # NOTE: 'list_segment_members' included data about members from different segment of the lists. There a
+                # possibility that a user can be a member for multiple segments. Thus, there will be duplication of records.
+                # Reference: https://jira.talendforge.org/browse/TDL-20303
+                if stream != "list_segment_members":
+                    self.assertEqual(len(primary_keys_list),
+                                     len(unique_primary_keys_list),
+                                     msg="Replicated record does not have unique primary key values.")

--- a/tests/test_mailchimp_bookmarks.py
+++ b/tests/test_mailchimp_bookmarks.py
@@ -1,7 +1,7 @@
 import tap_tester.connections as connections
 import tap_tester.runner as runner
 from base import MailchimpBaseTest
-from tap_tester import menagerie
+from tap_tester import menagerie, LOGGER
 
 
 class MailchimpBookMark(MailchimpBaseTest):

--- a/tests/unittests/test_reports_email_activities_PK.py
+++ b/tests/unittests/test_reports_email_activities_PK.py
@@ -1,5 +1,7 @@
 import unittest
-from tap_mailchimp.streams import transform_activities
+from tap_mailchimp.streams import ReportEmailActivity
+from tap_mailchimp.client import MailchimpClient
+from test_sync import Catalog
 
 class TestReportsEmailActivitiesPrimaryKey(unittest.TestCase):
     """Test case to verify we generate '_sdc_record_hash' for reports_email_activity"""
@@ -24,8 +26,21 @@ class TestReportsEmailActivitiesPrimaryKey(unittest.TestCase):
             }
         ]
 
+        # Mailchimp client
+        client = MailchimpClient(config={})
+
+        # 'reports_email_activity' stream object
+        stream = ReportEmailActivity(
+            state={},
+            client=client,
+            config={},
+            catalog=Catalog("reports_email_activity"),
+            selected_stream_names=["reports_email_activity"],
+            child_streams_to_sync=[]
+        )
+
         # Function call
-        transformed_records = list(transform_activities(records))
+        transformed_records = list(stream.transform_activities(records=records))
 
         # Verify we got transformed records
         self.assertIsNotNone(transformed_records)

--- a/tests/unittests/test_reports_email_activities_PK.py
+++ b/tests/unittests/test_reports_email_activities_PK.py
@@ -1,7 +1,9 @@
+import hashlib
 import unittest
 from tap_mailchimp.streams import ReportEmailActivity
 from tap_mailchimp.client import MailchimpClient
 from test_sync import Catalog
+
 
 class TestReportsEmailActivitiesPrimaryKey(unittest.TestCase):
     """Test case to verify we generate '_sdc_record_hash' for reports_email_activity"""
@@ -42,9 +44,18 @@ class TestReportsEmailActivitiesPrimaryKey(unittest.TestCase):
         # Function call
         transformed_records = list(stream.transform_activities(records=records))
 
+        # Create expected data by hashing the string of key-value pairs for ["campaign_id", "action", "email_id", "timestamp", "ip"] fields
+        expected_data = [
+            hashlib.sha256(
+                "campaign_id1actionopenemail_idf12345abcdtimestamp2022-01-01T10:15:22+00:00ip10.0.0.1".encode("utf-8")).hexdigest(),
+            hashlib.sha256(
+                "campaign_id1actionbounceemail_idf12345abcdtimestamp2022-01-02T19:11:48+00:00ip".encode("utf-8")).hexdigest()
+        ]
         # Verify we got transformed records
         self.assertIsNotNone(transformed_records)
 
-        # Verify '_sdc_records_hash' is present for all records
-        for record in transformed_records:
-            self.assertIsNotNone(record.get("_sdc_record_hash"))
+        # Verify '_sdc_records_hash' is present for all records and compare the hash with expected hash
+        for actual_record, expected_record in list(zip(transformed_records, expected_data)):
+            actual_record_hash = actual_record.get("_sdc_record_hash")
+            self.assertIsNotNone(actual_record_hash)
+            self.assertEqual(actual_record_hash, expected_record)

--- a/tests/unittests/test_reports_email_activities_PK.py
+++ b/tests/unittests/test_reports_email_activities_PK.py
@@ -1,0 +1,35 @@
+import unittest
+from tap_mailchimp.streams import transform_activities
+
+class TestReportsEmailActivitiesPrimaryKey(unittest.TestCase):
+    """Test case to verify we generate '_sdc_record_hash' for reports_email_activity"""
+
+    def test_reports_email_activities_PK(self):
+        # List of records
+        records = [
+            {
+                "campaign_id": 1,
+                "email_id": "f12345abcd",
+                "activity": [
+                    {
+                        "action": "open",
+                        "timestamp": "2022-01-01T10:15:22+00:00",
+                        "ip": "10.0.0.1"
+                    },
+                    {
+                        "action": "bounce",
+                        "timestamp": "2022-01-02T19:11:48+00:00"
+                    }
+                ]
+            }
+        ]
+
+        # Function call
+        transformed_records = list(transform_activities(records))
+
+        # Verify we got transformed records
+        self.assertIsNotNone(transformed_records)
+
+        # Verify '_sdc_records_hash' is present for all records
+        for record in transformed_records:
+            self.assertIsNotNone(record.get("_sdc_record_hash"))

--- a/tests/unittests/test_streams.py
+++ b/tests/unittests/test_streams.py
@@ -136,9 +136,12 @@ class StreamsTest(unittest.TestCase):
             Test case to verify that 'activity' field in records is transformed correctly.
         '''
 
-        transformed_record = streams.transform_activities(records = test_value1)
+        transformed_record = list(streams.transform_activities(records = test_value1))
+        for record in transformed_record:
+            # Remove the hash used for PK generation
+            record.pop("_sdc_record_hash")
 
-        self.assertEqual(list(transformed_record), test_value2)
+        self.assertEqual(transformed_record, test_value2)
 
 
 

--- a/tests/unittests/test_streams.py
+++ b/tests/unittests/test_streams.py
@@ -135,8 +135,20 @@ class StreamsTest(unittest.TestCase):
         '''
             Test case to verify that 'activity' field in records is transformed correctly.
         '''
+        # Mailchimp client
+        client = MailchimpClient(config={})
 
-        transformed_record = list(streams.transform_activities(records = test_value1))
+        # 'reports_email_activity' stream object
+        stream = streams.ReportEmailActivity(
+            state={},
+            client=client,
+            config={},
+            catalog=Catalog('reports_email_activity'),
+            selected_stream_names=['reports_email_activity'],
+            child_streams_to_sync=[]
+        )
+
+        transformed_record = list(stream.transform_activities(records = test_value1))
         for record in transformed_record:
             # Remove the hash used for PK generation
             record.pop("_sdc_record_hash")


### PR DESCRIPTION
# Description of change
TDL-20303: Primary keys are not correct for reports_email_activity and list_segment_members stream
- Updated the Primary Key for `report_email_activity` and used the hash of `['campaign_id', 'action', 'email_id', 'timestamp', 'ip']` as the Primary Key.

**NOTE:** In Mailchimp API we must pass a list of fields for which we want data to the Mailchimp API. As a result, we made `['campaign_id', 'action', 'email_id', 'timestamp', 'ip']` fields as automatic, as they are used to generate the Primary Key '_sdc record hash' Primary Key.
# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
