### PR TITLE
TDL-5866: All unsubscribe records being synced every run.

### DIFF
--- a/tap_mailchimp/streams.py
+++ b/tap_mailchimp/streams.py
@@ -129,18 +129,21 @@ class BaseStream:
         schema = stream.schema.to_dict()
         singer.write_schema(cls.stream_name, schema, stream.key_properties)
 
-    def process_records(self, records, max_bookmark_field=None):
+    def process_records(self, records, max_bookmark_field=None, sync_start=None):
         """Function to transform and write records and get the maximum bookmark value"""
         stream = self.stream
         schema = stream.schema.to_dict()
         stream_metadata = metadata.to_map(stream.metadata)
         with metrics.record_counter(self.stream_name) as counter, Transformer() as transformer:
             for record in records:
-                if self.replication_keys and (max_bookmark_field is None or record[self.replication_keys[0]] > max_bookmark_field):
-                    max_bookmark_field = record[self.replication_keys[0]]
                 record = transformer.transform(record,
                                                schema,
                                                stream_metadata)
+                # Skip records before the sync start date ie. (bookmark or start date)
+                if sync_start and record[self.replication_keys[0]] < sync_start:
+                    continue
+                if self.replication_keys and (max_bookmark_field is None or record[self.replication_keys[0]] > max_bookmark_field):
+                    max_bookmark_field = record[self.replication_keys[0]]
                 singer.write_record(self.stream_name, record)
                 counter.increment()
             return max_bookmark_field
@@ -253,7 +256,7 @@ class BaseStream:
 
             # If the stream is selected then write records
             if self.to_write_records:
-                max_bookmark_field = self.process_records(raw_records, max_bookmark_field)
+                max_bookmark_field = self.process_records(raw_records, max_bookmark_field, sync_start_date)
 
             # Sync 'reports' stream based on 'ids' collected for every record
             for report_stream in self.report_streams:
@@ -264,7 +267,8 @@ class BaseStream:
                     self.catalog, self.selected_stream_names, self.child_streams_to_sync)
                 reports_stream_obj.sync_report_activities(ids)
 
-            if self.bookmark_query_field:
+            # Write bookmark for Incremental streams
+            if self.bookmark_query_field or self.stream_name in ["unsubscribes"]:
                 self.write_bookmark(self.bookmark_path, max_bookmark_field)
 
             offset += page_size
@@ -352,13 +356,15 @@ class Campaigns(FullTable):
     data_key = stream_name
 
 
-class Unsubscribes(FullTable):
+class Unsubscribes(Incremental):
     """Class for 'unsubscribes' stream"""
     stream_name = 'unsubscribes'
     key_properties = ['campaign_id', 'email_id']
     path = '/reports/{}/unsubscribed'
     parent_streams = ['campaigns']
     data_key = stream_name
+    bookmark_path = [stream_name, '', 'timestamp']
+    replication_keys = ['timestamp']
 
 
 class ReportEmailActivity(Incremental):

--- a/tests/base.py
+++ b/tests/base.py
@@ -22,6 +22,7 @@ class MailchimpBaseTest(unittest.TestCase):
     OBEYS_START_DATE = "obey-start-date"
     BOOKMARK_PATH = "bookmark-path"
     BOOKMARK_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.000000Z"
+    PARENT = "parent-stream"
 
     def tap_name(self):
         """The name of the tap"""

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,10 +1,7 @@
 import unittest
-import datetime
 import os
 from tap_tester import menagerie, runner, connections, LOGGER
 from datetime import datetime as dt
-import dateutil.parser
-import pytz
 
 
 class MailchimpBaseTest(unittest.TestCase):
@@ -25,7 +22,7 @@ class MailchimpBaseTest(unittest.TestCase):
     OBEYS_START_DATE = "obey-start-date"
     BOOKMARK_PATH = "bookmark-path"
     RECORD_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.000000Z"
-    BOOKMARK_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S+00:00"
+    BOOKMARK_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.000000Z"
 
     def tap_name(self):
         """The name of the tap"""
@@ -115,9 +112,10 @@ class MailchimpBaseTest(unittest.TestCase):
             },
             "unsubscribes": {
                 self.PRIMARY_KEYS: {"campaign_id", "email_id"},
-                self.REPLICATION_METHOD: self.FULL_TABLE,
-                self.OBEYS_START_DATE: False,
-                self.BOOKMARK_PATH: None,
+                self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.OBEYS_START_DATE: True,
+                self.REPLICATION_KEYS: {"timestamp"},
+                self.BOOKMARK_PATH: ['unsubscribes', '5b483c58de', 'timestamp']
             },
         }
 

--- a/tests/test_mailchimp_bookmarks.py
+++ b/tests/test_mailchimp_bookmarks.py
@@ -71,13 +71,16 @@ class MailchimpBookMark(MailchimpBaseTest):
             "bookmarks": {
                 "lists": {
                     "8c775a04fb": {  # Verifying bookmark for single list's 'list_members'
-                        "list_members": {"datetime": "2022-08-01T06:23:35+00:00"}
+                        "list_members": {"datetime": "2022-08-01T06:23:35.000000Z"}
                     }
                 },
                 "reports_email_activity_next_chunk": 0,
                 "reports_email_activity_last_run_id": None,
                 "reports_email_activity": {  # Verifying bookmark for single campaign's 'reports_email_activity'
-                    "32e6edcecb": "2016-05-15T18:57:16+00:00"
+                    "32e6edcecb": "2016-05-15T18:57:16.000000Z"
+                },
+                "unsubscribes": { # Verifying bookmark for single campaign's 'unsubscribers'
+                    "5b483c58de": {"timestamp": "2014-10-23T23:37:21.000000Z"}
                 },
             }
         }

--- a/tests/test_mailchimp_interrupted_sync.py
+++ b/tests/test_mailchimp_interrupted_sync.py
@@ -65,7 +65,7 @@ class MailchimpInterruptedSyncTest(MailchimpBaseTest):
                 "lists": {
                     "8c775a04fb": {
                         "list_members": {
-                            "datetime": "2022-08-11T06:24:35+00:00"
+                            "datetime": "2022-08-11T06:24:35.000000Z"
                         }
                     }
                 }

--- a/tests/test_mailchimp_start_date.py
+++ b/tests/test_mailchimp_start_date.py
@@ -33,7 +33,7 @@ class MailchimpStartDate(MailchimpBaseTest):
 
     def run_test(self, expected_streams):
         self.start_date_1 = self.get_properties().get("start_date")
-        self.start_date_2 = "2014-07-01T00:00:00Z"
+        self.start_date_2 = "2014-10-23T00:00:00Z"
         self.start_date = self.start_date_1
 
         ##########################################################################

--- a/tests/unittests/test_unsubscribes.py
+++ b/tests/unittests/test_unsubscribes.py
@@ -1,0 +1,72 @@
+import unittest
+from unittest import mock
+from tap_mailchimp.streams import Unsubscribes
+from tap_mailchimp.client import MailchimpClient
+from parameterized import parameterized
+
+class Schema:
+    """
+    Class to provide required attributes for test cases.
+    """
+
+    def __init__(self, stream_name):
+        self.stream_name = stream_name
+
+    def to_dict(self):
+        return {"stream": self.stream_name}
+
+
+class Catalog:
+    """
+    Class to provide required attributes for test cases.
+    """
+
+    def __init__(self, stream_name):
+        self.stream_name = stream_name
+
+    def get_stream(self, stream_name):
+        return Streams(self.stream_name)
+
+
+class Streams:
+    """
+    Class to provide required attributes for test cases.
+    """
+
+    def __init__(self, stream_name):
+        self.stream_name = stream_name
+        self.path = "/test_path"
+        self.schema = Schema(stream_name)
+        self.key_properties = []
+        self.metadata = [{"breadcrumb": (), "metadata": {"valid-replication-keys": []}}]
+
+
+class TestUnsubcribes(unittest.TestCase):
+
+    stream_object = Unsubscribes(
+            state="",
+            client=MailchimpClient,
+            config={},
+            catalog=Catalog("unsubscribes"),
+            selected_stream_names=[Streams("unsubscribes")],
+            child_streams_to_sync=None,
+        )
+    
+    @parameterized.expand([
+        ['record_date_greater_then_sync_start_date', "2014-09-15T23:37:21.000000Z", "2014-09-21T23:37:21.000000Z"],
+        ['record_date_less_then_sync_start_date', "2014-09-22T23:37:21.000000Z", None],
+    ])
+    def test_process_records(self, name, sync_start_date, expected_bookmark):
+        """Test to verify sync for `unsubscribes`"""
+
+        object_ = self.stream_object
+
+        test_record = [
+            {"campaign_id": "test_campaign", "timestamp": "2014-09-21T23:37:21.000000Z"}
+        ]
+
+        actual_bookmark = object_.process_records(
+            records=test_record, max_bookmark_field=None, sync_start=sync_start_date
+        )
+        
+        self.assertEqual(actual_bookmark, expected_bookmark)


### PR DESCRIPTION
# Description of change
TDL-5866: All unsubscribe records being synced every run.
- Made unsubscribes stream as INCREMENTAL stream based in the timestamp field.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
