### PR TITLE
TDL-23577 fix `email_activity_date_window` validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.1
+  * Fixed Date Window Validation Error [#62](https://github.com/singer-io/tap-mailchimp/pull/62)
+
 ## 1.2.0
   * Date Window Implementation for reports_email_activity [#61](https://github.com/singer-io/tap-mailchimp/pull/61)
   

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-mailchimp',
-      version='1.2.0',
+      version='1.2.1',
       description='Singer.io tap for extracting data from the Mailchimp API',
       author='Stitch',
       url='https://singer.io',

--- a/tap_mailchimp/client.py
+++ b/tap_mailchimp/client.py
@@ -25,10 +25,12 @@ class MailchimpClient:
 
         # performs date-window calculation for fetching campaigns
         try:
-            date_window_duration = int(config.get('email_activity_date_window', 0))
+            date_window_duration = int(config.get('email_activity_date_window') or 0)
             self.adjusted_start_date = False if date_window_duration == 0 else \
                 (singer.utils.now().date() - singer.utils.datetime.timedelta(days = date_window_duration))
-        except ValueError:
+        # Raises TypeError for None / Null Value
+        # Raises ValueError for "" / bool value
+        except (ValueError, TypeError):
             LOGGER.info("Invalid Value: %s, for date windowing", config.get('email_activity_date_window', 0))
             LOGGER.critical("Date windowing disabled")
             self.adjusted_start_date = False

--- a/tests/unittests/test_date_window.py
+++ b/tests/unittests/test_date_window.py
@@ -6,7 +6,7 @@ class TestDateWindowConfig(unittest.TestCase):
     
     def test_datewindow_disabled_no_val(self):
         """
-            Verify if date_windowing is disabled if no value is passed
+            Verify that date_windowing is disabled if no value is passed
         """
         # Initialize MailchimpClient object
         client = MailchimpClient({'access_token': 'TOKEN'})
@@ -15,7 +15,7 @@ class TestDateWindowConfig(unittest.TestCase):
     
     def test_datewindow_disabled_empty_str(self):
         """
-            Verify if date_windowing is disabled if empty string value is passed
+            Verify that date_windowing is disabled if empty string value is passed
             Verify no Exception is raised for typecasting error between str to num
         """
         # Initialize MailchimpClient object
@@ -25,7 +25,7 @@ class TestDateWindowConfig(unittest.TestCase):
 
     def test_datewindow_disabled_bool_val(self):
         """
-            Verify if date_windowing is disabled if bool value is passed
+            Verify that date_windowing is disabled if bool value is passed
         """
         # Initialize MailchimpClient object
         client = MailchimpClient({'access_token': 'TOKEN',"email_activity_date_window":False})
@@ -33,15 +33,23 @@ class TestDateWindowConfig(unittest.TestCase):
 
     def test_datewindow_disabled_num_val(self):
         """
-            Verify if date_window is disabled if 0 value is passed
+            Verify that date_window is disabled if 0 value is passed
         """
         # Initialize MailchimpClient object
         client = MailchimpClient({'access_token': 'TOKEN',"email_activity_date_window":0})
         self.assertEqual(client.adjusted_start_date,False)
 
+    def test_datewindow_disabled_none_val(self):
+        """
+            Verify that date_window is disabled if None value is passed
+        """
+        # Initialize MailchimpClient object
+        client = MailchimpClient({'access_token': 'TOKEN',"email_activity_date_window":None})
+        self.assertEqual(client.adjusted_start_date,False)
+
     def test_datewindow_enabled_num_val(self):
         """
-            Verify if date_window is enabled if num value is passed
+            Verify that date_window is enabled if num value is passed
         """
         # Initialize MailchimpClient object
         client = MailchimpClient({'access_token': 'TOKEN',"email_activity_date_window":3})


### PR DESCRIPTION
# Description of change
- Fix Bug with handling `None` value for  property `email_activity_date_window` in tap config

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
