### PR TITLE
Implement Singer standard metadata support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             uv pip install --upgrade awscli
-            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
+            aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
             run-test --tap=tap-mailchimp tests
 workflows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 
 # 1.4.0
-  * Adds standered metadata [#74](https://github.com/singer-io/tap-mailchimp/pull/74)
-  * Bump dependencies for compliance
+  * Adds standard metadata [#74](https://github.com/singer-io/tap-mailchimp/pull/74)
+  * Bump dependencies requests to 2.34.2 and singer-python to 6.8.0
 
 # 1.3.3
   * Bump requests to 2.33.0 for security updates [#72](https://github.com/singer-io/tap-mailchimp/pull/72)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+
+# 1.4.0
+  * Adds standered metadata [#74](https://github.com/singer-io/tap-mailchimp/pull/74)
+  * Bump dependencies for compliance
+
 # 1.3.3
   * Bump requests to 2.33.0 for security updates [#72](https://github.com/singer-io/tap-mailchimp/pull/72)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-mailchimp',
-      version='1.3.3',
+      version='1.4.0',
       description='Singer.io tap for extracting data from the Mailchimp API',
       author='Stitch',
       url='https://singer.io',
@@ -11,8 +11,8 @@ setup(name='tap-mailchimp',
       py_modules=['tap_mailchimp'],
       install_requires=[
           'backoff==2.2.1',
-          'requests==2.33.0',
-          'singer-python==6.0.1'
+          'requests==2.34.2',
+          'singer-python==6.8.0'
       ],
       extras_require= {
           'dev': [

--- a/tap_mailchimp/discover.py
+++ b/tap_mailchimp/discover.py
@@ -1,6 +1,6 @@
 from singer.catalog import Catalog, CatalogEntry, Schema
 
-from tap_mailchimp.schema import get_schemas, PKS
+from tap_mailchimp.schema import get_schemas, STREAMS
 
 def discover():
     schemas, field_metadata = get_schemas()
@@ -9,7 +9,7 @@ def discover():
     for stream_name, schema_dict in schemas.items():
         schema = Schema.from_dict(schema_dict)
         metadata = field_metadata[stream_name]
-        pk = PKS[stream_name]
+        pk = STREAMS[stream_name]['key_properties']
 
         catalog.streams.append(CatalogEntry(
             stream=stream_name,

--- a/tap_mailchimp/schema.py
+++ b/tap_mailchimp/schema.py
@@ -24,6 +24,25 @@ REPLICATION_KEYS = {
     'list_members': ['last_changed'],
 }
 
+REPLICATION_METHODS = {
+    'automations': 'FULL_TABLE',
+    'campaigns': 'FULL_TABLE',
+    'list_segment_members': 'FULL_TABLE',
+    'list_segments': 'FULL_TABLE',
+    'lists': 'FULL_TABLE',
+    'unsubscribes': 'FULL_TABLE',
+    'list_members': 'INCREMENTAL',
+    'reports_email_activity': 'FULL_TABLE',
+}
+
+PARENT_STREAMS = {
+    'list_members': 'lists',
+    'list_segments': 'lists',
+    'list_segment_members': 'list_segments',
+    'unsubscribes': 'campaigns',
+    'reports_email_activity': 'campaigns',
+}
+
 def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
 
@@ -48,6 +67,23 @@ def get_schemas():
         replication_keys = REPLICATION_KEYS.get(stream_name, [])
 
         metadata = []
+
+        # Root-level stream metadata
+        root_metadata = {}
+        replication_method = REPLICATION_METHODS.get(stream_name)
+        if replication_method:
+            root_metadata['forced-replication-method'] = replication_method
+        if replication_keys:
+            root_metadata['valid-replication-keys'] = replication_keys
+        parent_stream = PARENT_STREAMS.get(stream_name)
+        if parent_stream:
+            root_metadata['parent-tap-stream-id'] = parent_stream
+        if root_metadata:
+            metadata.append({
+                'metadata': root_metadata,
+                'breadcrumb': []
+            })
+
         for prop in schema['properties'].keys():
             if prop in pk or prop in replication_keys:
                 inclusion = 'automatic'

--- a/tap_mailchimp/schema.py
+++ b/tap_mailchimp/schema.py
@@ -8,40 +8,44 @@ FIELD_METADATA = {}
 STREAMS = {
     'automations': {
         'key_properties': ['id'],
-        'replication_method': 'FULL_TABLE',
     },
     'campaigns': {
         'key_properties': ['id'],
-        'replication_method': 'FULL_TABLE',
     },
     'lists': {
         'key_properties': ['id'],
-        'replication_method': 'FULL_TABLE',
     },
     'list_members': {
-        'key_properties': ['id', 'list_id'],
+        'key_properties': [
+            'id',
+            'list_id'
+        ],
         'replication_method': 'INCREMENTAL',
         'replication_keys': ['last_changed'],
         'parent_stream': 'lists',
     },
     'list_segments': {
         'key_properties': ['id'],
-        'replication_method': 'FULL_TABLE',
         'parent_stream': 'lists',
     },
     'list_segment_members': {
         'key_properties': ['id'],
-        'replication_method': 'FULL_TABLE',
         'parent_stream': 'list_segments',
     },
     'reports_email_activity': {
-        'key_properties': ['campaign_id', 'action', 'email_id', 'timestamp'],
-        'replication_method': 'FULL_TABLE',
+        'key_properties': [
+            'campaign_id',
+            'action',
+            'email_id',
+            'timestamp'
+        ],
         'parent_stream': 'campaigns',
     },
     'unsubscribes': {
-        'key_properties': ['campaign_id', 'email_id'],
-        'replication_method': 'FULL_TABLE',
+        'key_properties': [
+            'campaign_id',
+            'email_id'
+        ],
         'parent_stream': 'campaigns',
     },
 }
@@ -70,7 +74,7 @@ def get_schemas():
             schema=schema,
             key_properties=stream_obj.get("key_properties"),
             valid_replication_keys=(stream_obj.get("replication_keys") or []),
-            replication_method=stream_obj.get("replication_method"),
+            replication_method=stream_obj.get("replication_method", "FULL_TABLE"),
         )
         mdata = metadata.to_map(mdata)
 

--- a/tap_mailchimp/schema.py
+++ b/tap_mailchimp/schema.py
@@ -1,100 +1,91 @@
 import os
 import json
+from singer import metadata
 
 SCHEMAS = {}
 FIELD_METADATA = {}
 
-PKS = {
-    'automations': ['id'],
-    'campaigns': ['id'],
-    'list_members': ['id', 'list_id'],
-    'list_segment_members': ['id'],
-    'list_segments': ['id'],
-    'lists': ['id'],
-    'reports_email_activity': [
-        'campaign_id',
-        'action',
-        'email_id',
-        'timestamp'
-    ],
-    'unsubscribes': ['campaign_id', 'email_id']
-}
-
-REPLICATION_KEYS = {
-    'list_members': ['last_changed'],
-}
-
-REPLICATION_METHODS = {
-    'automations': 'FULL_TABLE',
-    'campaigns': 'FULL_TABLE',
-    'list_segment_members': 'FULL_TABLE',
-    'list_segments': 'FULL_TABLE',
-    'lists': 'FULL_TABLE',
-    'unsubscribes': 'FULL_TABLE',
-    'list_members': 'INCREMENTAL',
-    'reports_email_activity': 'FULL_TABLE',
-}
-
-PARENT_STREAMS = {
-    'list_members': 'lists',
-    'list_segments': 'lists',
-    'list_segment_members': 'list_segments',
-    'unsubscribes': 'campaigns',
-    'reports_email_activity': 'campaigns',
+STREAMS = {
+    'automations': {
+        'key_properties': ['id'],
+        'replication_method': 'FULL_TABLE',
+    },
+    'campaigns': {
+        'key_properties': ['id'],
+        'replication_method': 'FULL_TABLE',
+    },
+    'lists': {
+        'key_properties': ['id'],
+        'replication_method': 'FULL_TABLE',
+    },
+    'list_members': {
+        'key_properties': ['id', 'list_id'],
+        'replication_method': 'INCREMENTAL',
+        'replication_keys': ['last_changed'],
+        'parent_stream': 'lists',
+    },
+    'list_segments': {
+        'key_properties': ['id'],
+        'replication_method': 'FULL_TABLE',
+        'parent_stream': 'lists',
+    },
+    'list_segment_members': {
+        'key_properties': ['id'],
+        'replication_method': 'FULL_TABLE',
+        'parent_stream': 'list_segments',
+    },
+    'reports_email_activity': {
+        'key_properties': ['campaign_id', 'action', 'email_id', 'timestamp'],
+        'replication_method': 'FULL_TABLE',
+        'parent_stream': 'campaigns',
+    },
+    'unsubscribes': {
+        'key_properties': ['campaign_id', 'email_id'],
+        'replication_method': 'FULL_TABLE',
+        'parent_stream': 'campaigns',
+    },
 }
 
 def get_abs_path(path):
+    """
+    Get the absolute path for the schema files.
+    """
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
 
 def get_schemas():
+    """Prepare metadata for each stream and return schema and metadata for the catalog."""
     global SCHEMAS, FIELD_METADATA # pylint: disable=global-statement
 
     if SCHEMAS:
         return SCHEMAS, FIELD_METADATA
 
-    schemas_path = get_abs_path('schemas')
-
-    file_names = [f for f in os.listdir(schemas_path)
-                  if os.path.isfile(os.path.join(schemas_path, f))]
-
-    for file_name in file_names:
-        stream_name = file_name[:-5]
-        with open(os.path.join(schemas_path, file_name), encoding='UTF-8') as data_file:
-            schema = json.load(data_file)
+    for stream_name, stream_obj in STREAMS.items():
+        schema_path = get_abs_path("schemas/{}.json".format(stream_name))
+        with open(schema_path, encoding='UTF-8') as file:
+            schema = json.load(file)
 
         SCHEMAS[stream_name] = schema
-        pk = PKS[stream_name]
-        replication_keys = REPLICATION_KEYS.get(stream_name, [])
 
-        metadata = []
+        mdata = metadata.get_standard_metadata(
+            schema=schema,
+            key_properties=stream_obj.get("key_properties"),
+            valid_replication_keys=(stream_obj.get("replication_keys") or []),
+            replication_method=stream_obj.get("replication_method"),
+        )
+        mdata = metadata.to_map(mdata)
 
-        # Root-level stream metadata
-        root_metadata = {}
-        replication_method = REPLICATION_METHODS.get(stream_name)
-        if replication_method:
-            root_metadata['forced-replication-method'] = replication_method
-        if replication_keys:
-            root_metadata['valid-replication-keys'] = replication_keys
-        parent_stream = PARENT_STREAMS.get(stream_name)
-        if parent_stream:
-            root_metadata['parent-tap-stream-id'] = parent_stream
-        if root_metadata:
-            metadata.append({
-                'metadata': root_metadata,
-                'breadcrumb': []
-            })
+        automatic_keys = stream_obj.get("replication_keys") or []
+        for field_name in schema["properties"].keys():
+            if field_name in automatic_keys:
+                mdata = metadata.write(
+                    mdata, ("properties", field_name), "inclusion", "automatic"
+                )
 
-        for prop in schema['properties'].keys():
-            if prop in pk or prop in replication_keys:
-                inclusion = 'automatic'
-            else:
-                inclusion = 'available'
-            metadata.append({
-                'metadata': {
-                    'inclusion': inclusion
-                },
-                'breadcrumb': ['properties', prop]
-            })
-        FIELD_METADATA[stream_name] = metadata
+        parent_tap_stream_id = stream_obj.get("parent_stream")
+        if parent_tap_stream_id:
+            mdata = metadata.write(mdata, (), 'parent-tap-stream-id', parent_tap_stream_id)
+
+        mdata = metadata.to_list(mdata)
+        FIELD_METADATA[stream_name] = mdata
 
     return SCHEMAS, FIELD_METADATA


### PR DESCRIPTION
# Description of change
This PR updates the tap’s discovery/schema handling to emit Singer “standard metadata” (including replication and parent stream metadata), and bumps the package/dependency versions accordingly. [SAC-31303](https://qlik-dev.atlassian.net/browse/SAC-31303)

# Changes:
 - Consolidated PKS, REPLICATION_KEYS, REPLICATION_METHODS, and PARENT_STREAMS into a single STREAMS dictionary in schema.py for better maintainability.
 - Updated get_schemas() to iterate over STREAMS directly instead of listing files from the schemas directory.
 - Replaced manual metadata construction with Singer's standard metadata helpers (get_standard_metadata, to_map, write, to_list).

# Manual QA steps
- [x]  Discovery: Running
- [x]  Sync: Running
- [x]  Unit test
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
